### PR TITLE
Change the PHP Design Pattern resource to Refactoring Guru Design Pattern resource (Closes #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The repository is created when working on the following YouTube video [PHP Devel
 |---------------------------------------------------|--------|------------------------------|
 | Design Patterns in Plain English                  | 1h 20m | https://youtu.be/NU_1StN5Tkk |
 | 5 Design Patterns Every Engineer Should Know      | 12m    | https://youtu.be/FLmBqI3IKMAo |
-| Design Patterns in PHP                            | N/A    | https://designpatternsphp.readthedocs.io/en/latest/README.html |
+| Design Patterns                                   | N/A    | https://refactoring.guru/design-patterns |
 | SOLID principles                                  | N/A    | https://www.cleancode.studio/series/solid-principles |
 | The No-Framework Tutorial                         | N/A    | https://github.com/PatrickLouys/no-framework-tutorial |
 


### PR DESCRIPTION
I changed the resource of the Design Pattern PHP after it is marked as a spam and became not found to the Refactoring Guru design pattern resource. Closes #24 